### PR TITLE
Song History Heatmap

### DIFF
--- a/app/assets/stylesheets/listening_patterns.scss
+++ b/app/assets/stylesheets/listening_patterns.scss
@@ -100,3 +100,50 @@
 .recent-grid .text-light {
   color: #f8f9fa !important;
 }
+
+/* Calendar heatmap */
+.heatmap-wrapper {
+  display: flex;
+  justify-content: center;
+  padding: 12px;
+}
+
+.heatmap-grid {
+  display: grid;
+  grid-auto-flow: column;
+  gap: 6px;
+  padding: 10px;
+  justify-content: center;
+}
+
+.heatmap-week {
+  display: grid;
+  grid-template-rows: repeat(7, 22px);
+  gap: 6px;
+}
+
+.heatmap-cell {
+  width: 22px;
+  height: 22px;
+  border-radius: 5px;
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.heatmap-legend .legend-cell {
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  display: inline-block;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.heatmap-cell.level-0,
+.legend-cell.level-0 { background-color: rgba(255, 255, 255, 0.05); }
+.heatmap-cell.level-1,
+.legend-cell.level-1 { background-color: rgba(29, 185, 84, 0.25); }
+.heatmap-cell.level-2,
+.legend-cell.level-2 { background-color: rgba(29, 185, 84, 0.45); }
+.heatmap-cell.level-3,
+.legend-cell.level-3 { background-color: rgba(29, 185, 84, 0.65); }
+.heatmap-cell.level-4,
+.legend-cell.level-4 { background-color: rgba(29, 185, 84, 0.85); }

--- a/app/controllers/listening_patterns_controller.rb
+++ b/app/controllers/listening_patterns_controller.rb
@@ -1,14 +1,18 @@
 class ListeningPatternsController < ApplicationController
   before_action :require_spotify_auth!
 
-  VALID_LIMITS = [ 25, 50 ].freeze
+  VALID_LIMITS = [ 50, 100, 250, 500, 1000 ].freeze
 
   def hourly
     @limit = normalize_limit(params[:limit])
     client = SpotifyClient.new(session: session)
+    history = ListeningHistory.new(spotify_user_id: spotify_user_id)
 
-    plays = client.recently_played(limit: @limit)
-    @sample_size = Array(plays).size
+    # Fetch new data from Spotify (~50), persist to DB, then read as many as requested
+    ingest_recent_plays!(client: client, history: history, fetch_limit: 200)
+
+    plays = history.recent_entries(limit: @limit)
+    @sample_size = plays.size
     zoned_times = []
     hourly_counts = Array.new(24, 0)
 
@@ -40,6 +44,46 @@ class ListeningPatternsController < ApplicationController
       @top_hours = []
       @history_window = nil
       @sample_tracks = []
+    end
+  end
+
+  def calendar
+    client = SpotifyClient.new(session: session)
+    history = ListeningHistory.new(spotify_user_id: spotify_user_id)
+
+    ingest_recent_plays!(client: client, history: history, fetch_limit: 200)
+    plays = history.recent_entries(limit: 500) # use larger window for calendar if available
+    @sample_size = plays.size
+
+    date_counts = Hash.new(0)
+    timestamps  = []
+
+    Array(plays).each do |play|
+      time = normalize_time(play.played_at)
+      next unless time
+      timestamps << time
+      date_counts[time.to_date] += 1
+    end
+
+    today      = Time.zone ? Time.zone.today : Date.today
+    start_date = align_to_week_start(today - 55) # ~8 weeks, GitHub-style grid
+    end_date   = today
+    max_count  = date_counts.values.max.to_i
+
+    @weeks = build_weeks(start_date, end_date, date_counts, max_count)
+    @history_window = build_history_window(timestamps)
+  rescue SpotifyClient::UnauthorizedError
+    redirect_to home_path, alert: "You must log in with spotify to view your listening patterns." and return
+  rescue SpotifyClient::Error => e
+    if insufficient_scope?(e)
+      reset_spotify_session!
+      redirect_to login_path, alert: "Spotify now needs permission to read your Recently Played history. Please sign in again." and return
+    else
+      Rails.logger.warn "Failed to fetch listening calendar data: #{e.message}"
+      flash.now[:alert] = "We weren't able to load your listening history from Spotify right now."
+      @weeks = []
+      @history_window = nil
+      @sample_size = 0
     end
   end
 
@@ -92,6 +136,48 @@ class ListeningPatternsController < ApplicationController
   def build_history_window(times)
     return nil if times.blank?
     [ times.min, times.max ]
+  end
+
+  def align_to_week_start(date)
+    date - date.wday
+  end
+
+  def ingest_recent_plays!(client:, history:, fetch_limit:)
+    recent = client.recently_played(limit: fetch_limit)
+    history.ingest!(recent)
+  end
+
+  def spotify_user_id
+    session.dig(:spotify_user, "id")
+  end
+
+  def build_weeks(start_date, end_date, counts, max_count)
+    cells = []
+    date = start_date
+
+    while date <= end_date
+      count = counts[date]
+      cells << {
+        date: date,
+        count: count,
+        level: intensity_level(count, max_count)
+      }
+      date += 1
+    end
+
+    cells.each_slice(7).to_a
+  end
+
+  def intensity_level(count, max)
+    return 0 if count.to_i <= 0 || max <= 0
+    ratio = count.to_f / max.to_f
+
+    case ratio
+    when 0...0.25 then 1
+    when 0.25...0.5 then 2
+    when 0.5...0.75 then 3
+    else 4
+    end
   end
 
   def insufficient_scope?(error)

--- a/app/models/listening_play.rb
+++ b/app/models/listening_play.rb
@@ -1,0 +1,4 @@
+class ListeningPlay < ApplicationRecord
+  validates :spotify_user_id, presence: true
+  validates :played_at, presence: true
+end

--- a/app/services/listening_history.rb
+++ b/app/services/listening_history.rb
@@ -1,0 +1,79 @@
+require "ostruct"
+
+class ListeningHistory
+  def initialize(spotify_user_id:)
+    @spotify_user_id = spotify_user_id
+  end
+
+  def ingest!(plays)
+    rows = Array(plays).map do |play|
+      time = extract_time(play)
+      next unless time
+
+      {
+        spotify_user_id: spotify_user_id,
+        track_id: play.respond_to?(:id) ? play.id : play[:id],
+        track_name: play.respond_to?(:name) ? play.name : play[:name],
+        artists: extract_artists(play),
+        album_name: safe_get(play, :album_name),
+        album_image_url: safe_get(play, :album_image_url),
+        preview_url: safe_get(play, :preview_url),
+        spotify_url: safe_get(play, :spotify_url),
+        played_at: time,
+        created_at: Time.current,
+        updated_at: Time.current
+      }
+    end.compact
+
+    return if rows.empty?
+
+    ListeningPlay.insert_all(rows, unique_by: :index_listening_plays_on_user_track_played_at)
+  end
+
+  def recent_entries(limit:)
+    ListeningPlay
+      .where(spotify_user_id: spotify_user_id)
+      .order(played_at: :desc)
+      .limit(limit)
+      .map { |rec| to_entry(rec) }
+  end
+
+  private
+
+  attr_reader :spotify_user_id
+
+  def to_entry(rec)
+    OpenStruct.new(
+      id: rec.track_id,
+      name: rec.track_name,
+      artists: rec.artists,
+      album_name: rec.album_name,
+      album_image_url: rec.album_image_url,
+      preview_url: rec.preview_url,
+      spotify_url: rec.spotify_url,
+      played_at: rec.played_at
+    )
+  end
+
+  def extract_time(play)
+    if play.respond_to?(:played_at)
+      play.played_at
+    else
+      play[:played_at]
+    end
+  end
+
+  def extract_artists(play)
+    if play.respond_to?(:artists)
+      play.artists
+    else
+      play[:artists]
+    end
+  end
+
+  def safe_get(play, key)
+    play.respond_to?(key) ? play.public_send(key) : play[key]
+  rescue NoMethodError
+    nil
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,6 +43,7 @@
             <%= link_to "Top Tracks", top_tracks_path, class: "nav-link #{'active' if current_page?(top_tracks_path)}" %>
             <%= link_to "Top Artists", top_artists_path, class: "nav-link #{'active' if current_page?(top_artists_path)}" %>
             <%= link_to "Listening Pattern", listening_patterns_path, class: "nav-link #{'active' if current_page?(listening_patterns_path)}" %>
+            <%= link_to "Listening Heatmap", listening_heatmap_path, class: "nav-link #{'active' if current_page?(listening_heatmap_path)}" %>
             <%= link_to "Recommendations", recommendations_path, class: "nav-link #{'active' if current_page?(recommendations_path)}" %>
           <% end %>
         </div>

--- a/app/views/listening_patterns/calendar.html.erb
+++ b/app/views/listening_patterns/calendar.html.erb
@@ -1,0 +1,70 @@
+<% content_for :extra_css do %>
+  <%= stylesheet_link_tag "listening_patterns", media: "all" %>
+<% end %>
+
+<main class="container listening-patterns mt-4">
+  <div class="page-heading d-flex flex-column flex-lg-row align-items-lg-center justify-content-lg-between">
+    <div>
+      <p class="eyebrow text-uppercase mb-1">Listening Calendar</p>
+      <h1 class="text-light mb-2">Your activity heatmap</h1>
+      <p class="text-secondary mb-0">
+        GitHub-style calendar showing when you hit play. We sync your recent plays and keep them so the grid can fill up over time.
+      </p>
+      <% if @history_window.present? %>
+        <% start_time, end_time = @history_window %>
+        <p class="text-secondary small mb-0">
+          Window: <%= start_time.strftime("%b %-d, %l:%M %p %Z") %> – <%= end_time.strftime("%b %-d, %l:%M %p %Z") %>
+        </p>
+      <% end %>
+    </div>
+
+    <div class="total-chip text-light mt-3 mt-lg-0">
+      <span class="label text-secondary">Plays captured</span>
+      <span class="value text-light"><%= @sample_size %></span>
+    </div>
+  </div>
+
+  <% if @weeks.present? %>
+    <div class="spotify-card p-3 mt-4">
+      <div class="d-flex justify-content-between align-items-center mb-3">
+        <div>
+          <h5 class="text-light mb-1">Calendar heatmap</h5>
+          <p class="text-secondary small mb-0">
+            Shows the last ~8 weeks from your Recently Played feed. Darker squares mean more plays that day.
+          </p>
+        </div>
+        <div class="heatmap-legend d-flex align-items-center gap-1">
+          <span class="text-secondary small me-2">Less</span>
+          <% (0..4).each do |level| %>
+            <span class="legend-cell level-<%= level %>"></span>
+          <% end %>
+          <span class="text-secondary small ms-2">More</span>
+        </div>
+      </div>
+
+      <div class="heatmap-wrapper">
+        <div class="heatmap-grid" style="grid-template-columns: repeat(<%= @weeks.size %>, 22px);">
+          <% @weeks.each do |week| %>
+            <div class="heatmap-week">
+              <% week.each do |cell| %>
+                <div
+                  class="heatmap-cell level-<%= cell[:level] %>"
+                  title="<%= "#{cell[:date].strftime('%b %-d')}: #{cell[:count]} play#{'s' unless cell[:count] == 1}" %>">
+                </div>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  <% else %>
+    <div class="spotify-card p-4 mt-4">
+      <h5 class="text-light">No recent plays yet</h5>
+      <p class="text-secondary mb-2">
+        We need a little listening history to build your calendar. Play a few tracks on Spotify,
+        then refresh this page.
+      </p>
+      <%= link_to "Refresh", listening_heatmap_path, class: "btn btn-spotify" %>
+    </div>
+  <% end %>
+</main>

--- a/app/views/listening_patterns/hourly.html.erb
+++ b/app/views/listening_patterns/hourly.html.erb
@@ -8,7 +8,7 @@
       <p class="eyebrow text-uppercase mb-1">Hour-of-Day Listening Pattern</p>
       <h1 class="text-light mb-2">When you hit play</h1>
       <p class="text-secondary mb-0">
-        We look at your recently played tracks and chart how often you listen during each hour of the day.
+        We look at your played tracks (we keep syncing them for you) and chart how often you listen during each hour of the day.
         Times are shown in <%= Time.zone.name || "UTC" %>.
       </p>
     </div>
@@ -17,7 +17,13 @@
       <%= form_with url: listening_patterns_path, method: :get, local: true, class: "d-flex align-items-center gap-2 limit-form" do %>
         <label class="text-secondary fw-semibold">Use last</label>
         <%= select_tag :limit,
-              options_for_select([["25 plays", 25], ["50 plays (max)", 50]], @limit),
+              options_for_select([
+                ["50 plays", 50],
+                ["100 plays", 100],
+                ["250 plays", 250],
+                ["500 plays", 500],
+                ["1000 plays", 1000]
+              ], @limit),
               class: "form-select form-select-sm bg-dark text-white border-secondary",
               onchange: "this.form.submit();" %>
         <button class="btn btn-dark btn-sm js-hidden" type="submit">↻</button>
@@ -56,7 +62,7 @@
             Bars show how many of your last <%= @sample_size %> plays happened during each hour of the day.
           </p>
           <p class="text-secondary small mb-0">
-            Spotify caps Recently Played at ~50 tracks from roughly the past 24 hours, so this view will top out there.
+            We keep a running history per account so you can request up to <%= @limit %> plays beyond Spotify's short window.
           </p>
         </div>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   get "/view-profile", to: "pages#view_profile", as: :view_profile
   get "/clear", to: "pages#clear", as: :clear
   get "/listening-patterns", to: "listening_patterns#hourly", as: :listening_patterns
+  get "/listening-heatmap", to: "listening_patterns#calendar", as: :listening_heatmap
   root "pages#home"
 
   # Callback from Spotify

--- a/db/migrate/20251124000000_create_listening_plays.rb
+++ b/db/migrate/20251124000000_create_listening_plays.rb
@@ -1,0 +1,20 @@
+class CreateListeningPlays < ActiveRecord::Migration[7.1]
+  def change
+    create_table :listening_plays do |t|
+      t.string :spotify_user_id, null: false
+      t.string :track_id
+      t.string :track_name
+      t.string :artists
+      t.string :album_name
+      t.string :album_image_url
+      t.datetime :played_at, null: false
+      t.string :preview_url
+      t.string :spotify_url
+
+      t.timestamps
+    end
+
+    add_index :listening_plays, [ :spotify_user_id, :track_id, :played_at ], unique: true, name: "index_listening_plays_on_user_track_played_at"
+    add_index :listening_plays, [ :spotify_user_id, :played_at ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_11_23_234244) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_24_000000) do
   create_table "followed_artist_batches", force: :cascade do |t|
     t.string "spotify_user_id"
     t.integer "limit"
@@ -31,6 +31,22 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_23_234244) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["followed_artist_batch_id"], name: "index_followed_artists_on_followed_artist_batch_id"
+  end
+
+  create_table "listening_plays", force: :cascade do |t|
+    t.string "spotify_user_id", null: false
+    t.string "track_id"
+    t.string "track_name"
+    t.string "artists"
+    t.string "album_name"
+    t.string "album_image_url"
+    t.datetime "played_at", null: false
+    t.string "preview_url"
+    t.string "spotify_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["spotify_user_id", "played_at"], name: "index_listening_plays_on_spotify_user_id_and_played_at"
+    t.index ["spotify_user_id", "track_id", "played_at"], name: "index_listening_plays_on_user_track_played_at", unique: true
   end
 
   create_table "new_release_batches", force: :cascade do |t|

--- a/features/listening_heatmap.feature
+++ b/features/listening_heatmap.feature
@@ -1,0 +1,14 @@
+Feature: Listening heatmap page
+  As a listener
+  I want to see a calendar heatmap of my recent plays
+  So I can visualize my listening patterns
+
+  Background:
+    Given OmniAuth is in test mode
+    And I am signed in with Spotify
+
+  Scenario: Viewing the heatmap with recent plays
+    Given Spotify returns 3 recent plays across days
+    When I visit "/listening-heatmap"
+    Then I should see "Calendar heatmap"
+    And I should see "Plays captured"

--- a/features/step_definitions/listening_heatmap_steps.rb
+++ b/features/step_definitions/listening_heatmap_steps.rb
@@ -1,0 +1,14 @@
+require "ostruct"
+
+Given("Spotify returns 3 recent plays across days") do
+  base_date = Date.today
+  plays = [
+    OpenStruct.new(id: "t1", name: "One", artists: "A", played_at: base_date.to_time),
+    OpenStruct.new(id: "t2", name: "Two", artists: "B", played_at: (base_date - 1).to_time),
+    OpenStruct.new(id: "t3", name: "Three", artists: "C", played_at: (base_date - 2).to_time)
+  ]
+
+  allow_any_instance_of(SpotifyClient)
+    .to receive(:recently_played)
+    .and_return(plays)
+end

--- a/features/step_definitions/pages_top_tracks_steps.rb
+++ b/features/step_definitions/pages_top_tracks_steps.rb
@@ -21,6 +21,7 @@ Given("a test endpoint that proxies to pages#top_tracks") do
     get '/view-profile', to: 'pages#view_profile', as: :view_profile
     get '/clear',        to: 'pages#clear',        as: :clear
     get '/listening-patterns', to: 'listening_patterns#hourly', as: :listening_patterns
+    get '/listening-heatmap',  to: 'listening_patterns#calendar', as: :listening_heatmap
     root 'pages#home'
     match '/auth/spotify/callback', to: 'sessions#create', via: %i[get post]
     get '/auth/failure', to: "sessions#failure"

--- a/spec/features/listening_heatmap_spec.rb
+++ b/spec/features/listening_heatmap_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe "Listening Heatmap page", type: :feature do
+  before do
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:spotify] = OmniAuth::AuthHash.new(
+      provider: "spotify",
+      uid: "spotify-uid-123",
+      info: {
+        name:  "Test User",
+        email: "test-user@example.com",
+        image: "https://pics.example/avatar.png"
+      },
+      credentials: {
+        token:         "access-token-1",
+        refresh_token: "refresh-token-1",
+        expires_at:    2.hours.from_now.to_i
+      }
+    )
+  end
+
+  let(:plays) do
+    [
+      OpenStruct.new(id: "t1", name: "One", artists: "A", played_at: Time.utc(2025, 1, 1, 10, 0, 0)),
+      OpenStruct.new(id: "t2", name: "Two", artists: "B", played_at: Time.utc(2025, 1, 2, 12, 0, 0))
+    ]
+  end
+
+  it "renders the calendar heatmap with sample size" do
+    allow_any_instance_of(SpotifyClient).to receive(:recently_played).and_return(plays)
+
+    visit "/auth/spotify"
+    visit "/auth/spotify/callback"
+    visit listening_heatmap_path
+
+    expect(page).to have_content("Calendar heatmap")
+    expect(page).to have_content("Plays captured")
+    expect(page).to have_content("2")
+  end
+end

--- a/spec/services/listening_history_spec.rb
+++ b/spec/services/listening_history_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe ListeningHistory do
+  let(:spotify_user_id) { "user-123" }
+  let(:history) { described_class.new(spotify_user_id: spotify_user_id) }
+
+  describe "#ingest! and #recent_entries" do
+    it "stores plays and returns them in descending order" do
+      plays = [
+        OpenStruct.new(id: "t1", name: "One", artists: "A", played_at: Time.utc(2025, 1, 2, 10, 0, 0)),
+        OpenStruct.new(id: "t2", name: "Two", artists: "B", played_at: Time.utc(2025, 1, 1, 10, 0, 0))
+      ]
+
+      history.ingest!(plays)
+      entries = history.recent_entries(limit: 10)
+
+      expect(entries.map(&:id)).to eq(%w[t1 t2])
+      expect(ListeningPlay.count).to eq(2)
+    end
+
+    it "deduplicates by user + track + played_at" do
+      time = Time.utc(2025, 1, 1, 12, 0, 0)
+      dup_play = OpenStruct.new(id: "t1", name: "One", artists: "A", played_at: time)
+
+      history.ingest!([ dup_play, dup_play ])
+
+      expect(ListeningPlay.count).to eq(1)
+      expect(history.recent_entries(limit: 5).size).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
Solves issue #12 by implementing:
A heatmap page that will display listening history Added storage for users so more than 50 songs can be display This helps for both issue #7 and issue #12 as saving more than 50 songs is valuable (some people listen to easily over 50 in 1 day)
Note: You need to be using the app consistently to save the data, since Spotify will only know the most recent 50.